### PR TITLE
fix: upper bound torchaudio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -187,7 +187,7 @@ def do_setup(package_data):
             "torch==1.13.1",
             "tqdm",
             "bitarray",
-            "torchaudio>=0.8.0",
+            "torchaudio>=0.8.0, <2.2.2",
             "scikit-learn",
             "packaging",
         ],


### PR DESCRIPTION
The [latest pytorch release](https://github.com/pytorch/pytorch/releases/tag/v2.2.2) (2.2.2) requires gcc 9 or higher. This impacts torchaudio, and broke our build. This PR adds an upper bound on the torchaudio version so this doesn't break.