### PR TITLE
fix: upper bound to torch version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
   "wheel",
   "cython",
   "numpy>=1.21.3",
-  "torch>=1.10",
+  "torch>=1.10, <2.2.1",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Torch doesn't have an upper bound in the pyproject.toml file so adding one there, perhaps this will properly restrict all version things